### PR TITLE
Render both summary and description in RSS feeds

### DIFF
--- a/build.js
+++ b/build.js
@@ -68,7 +68,8 @@ function renderRSS(context) {
     feed.item({
       title: article.ourNameForTheAuthor + ': ' + article.title,
       url: article.link,
-      description: article.summary,
+      summary: article.summary,
+      description: article.description,
       date: article.pubdate
     });
     if (article.author) {


### PR DESCRIPTION
Re: comments in PR https://github.com/toolness/planet-badges/pull/4

echo both the summary and description of the original article to the aggregated feed
